### PR TITLE
chore: remove baseurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This repository hosts the **AI Coding Manifesto** - a set of principles for ethical and effective human-AI collaboration in software development.
 The AI Coding Manifesto establishes guidelines for transparency, accountability, and human agency while harnessing AI's capabilities to enhance productivity and code quality in software development.
 
+Live website: [ai-coding-manifesto.github.io](https://ai-coding-manifesto.github.io)
+
 ## Contributing
 
 We welcome contributions to improve the manifesto content, website design, or add translations. Please:

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: AI Coding Manifesto
 description: Best Practices for AI-Assisted Contributions in Open Source
 url: "https://ai-coding-manifesto.github.io"
-baseurl: "/ai-coding-manifesto"
+baseurl: ""
 
 markdown: kramdown
 highlighter: rouge


### PR DESCRIPTION
So the website is only ai-coding-manifesto.github.io